### PR TITLE
Stop using material components JS for snackbar

### DIFF
--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -228,8 +228,7 @@ export default {
         this.registerSuccess = true
         showSnackbar({
           message: 'Your account was successfully registered. ' +
-            'You will be logged in automatically in a few seconds.',
-          multiline: true
+            'You will be logged in automatically in a few seconds.'
         })
         setTimeout(() => {
           login(this.user.username, this.user.password).then(() => {

--- a/src/components/Snackbar.vue
+++ b/src/components/Snackbar.vue
@@ -1,36 +1,50 @@
 <template>
   <div
-      ref="snackbar"
-      class="mdc-snackbar"
+      v-if="active"
+      class="mdc-snackbar mdc-snackbar--active"
+      :class="{
+        'mdc-snackbar--multiline': multiline
+      }"
       aria-live="assertive"
-      aria-atomic="true"
-      aria-hidden="true">
+      aria-atomic="true">
     <div class="mdc-snackbar__text">
-    </div>
-    <div class="mdc-snackbar__action-wrapper">
-      <button type="button" class="mdc-snackbar__action-button"></button>
+      {{ text }}
     </div>
   </div>
 </template>
 
 <script>
-import { MDCSnackbar } from '@material/snackbar'
-
 import { initSnackbar } from '@/snackbar'
 
 export default {
   name: 'Snackbar',
   data: function () {
     return {
-      ui: {
-        snackbar: null
-      }
+      active: false,
+      text: '',
+      timeout: null
     }
   },
   mounted: function () {
-    if (this.ui.snackbar === null) {
-      this.ui.snackbar = new MDCSnackbar(this.$refs.snackbar)
-      initSnackbar(this.ui.snackbar)
+    initSnackbar(this)
+  },
+  computed: {
+    multiline () {
+      return this.text.length > 40
+    }
+  },
+  methods: {
+    show ({ message }) {
+      if (this.timeout !== null) {
+        clearTimeout(this.timeout)
+      }
+
+      this.active = true
+      this.text = message
+
+      this.timeout = setTimeout(() => {
+        this.active = false
+      }, 3000)
     }
   }
 }


### PR DESCRIPTION
The upstream JS code that takes care of showing/hiding the snackbar is
buggy, it does not hide the snackbar under certain circumstances. This
commit implements primitive logic within the Vue component for the
snackbar.