### PR TITLE
Prevent horizontal scrolling: Limit tooltip width; move day tooltips …

### DIFF
--- a/src/assets/scss/base.scss
+++ b/src/assets/scss/base.scss
@@ -145,3 +145,11 @@ a {
 .mdc-list-item__meta {
   text-align: center;
 }
+
+
+// fix tooltip max width to prevent horizontal scrolling
+.tooltip {
+  &::after {
+    max-width: 30vw;
+  }
+}

--- a/src/components/Day.vue
+++ b/src/components/Day.vue
@@ -11,7 +11,7 @@
       <span class="float-right">
         {{ maxDuration.toNumber() }}h
         <span
-            class="tooltip tooltip-bottom"
+            class="tooltip tooltip-left"
               data-tooltip="Max duration for this day">
           <i class="material-icons normal-whitespace small">
             watch_later
@@ -35,7 +35,7 @@
       <span class="float-right">
         {{ unfinishedScheduledDuration.toNumber() }}h/{{ scheduledDuration.toNumber() }}h
         <span
-            class="tooltip"
+            class="tooltip tooltip-left"
             data-tooltip="Unfinished/total scheduled duration">
           <i class="material-icons normal-whitespace small">
             access_time


### PR DESCRIPTION
…to the left

This commit fixes the horizontal scrolling problem: If the tooltips are
wider than the screen (even when hidden), horizontal scrolling is
allowed. This especially happens on devices with small screens like
smartphones.